### PR TITLE
OX10 is a valid outward postcode section

### DIFF
--- a/postcode_validator_uk/rules.py
+++ b/postcode_validator_uk/rules.py
@@ -45,12 +45,13 @@ class DoubleDigitDistrict(PostcodeRule):
 class ZeroOrTenDistrict(PostcodeRule):
     """
     Areas with a district '0' (zero): BL, BS, CM, CR, FY, HA, PR, SL, SS
-    (BS is the only area to have both a district 0 and a district 10)
+    (BS is the only area to have both a district 0 and a district 10, and OX
+    only has a district 10)
     """
 
     attr_applied = "outward"
     applied_areas_regex = re.compile(r"^[A-Z]{2}(0|10)$")
-    rule_regex = re.compile(r"^(BL|BS|CM|CR|FY|HA|PR|SL|SS)0$|^BS10$")
+    rule_regex = re.compile(r"^(BL|BS|CM|CR|FY|HA|PR|SL|SS)0$|^BS10$|^OX10$")
 
 
 class CentralLondonDistrict(PostcodeRule):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -36,7 +36,7 @@ SINGLE_DIGIT_DISTRICTS_AREAS = (
     "ZE",
 )
 DOUBLE_DIGIT_DISTRICTS_AREAS = ("AB", "LL", "SO")
-ZERO_OR_TEN_DISTRICTS_AREAS = ("BL", "BS", "CM", "CR", "FY", "HA", "PR", "SL", "SS")
+ZERO_OR_TEN_DISTRICTS_AREAS = ("BL", "BS", "CM", "CR", "FY", "HA", "OX", "PR", "SL", "SS")
 
 
 class TestPostcodeRule:
@@ -143,14 +143,18 @@ class TestZeroOrTenDistrict:
         postcode = mock.Mock(outward=f"{area}0")
         rule = ZeroOrTenDistrict(postcode)
 
-        assert rule.validate() is None
+        if area in ["OX"]:
+            with pytest.raises(InvalidPostcode):
+                rule.validate()
+        else:
+            assert rule.validate() is None
 
     @pytest.mark.parametrize("area", ZERO_OR_TEN_DISTRICTS_AREAS)
     def test_validating_valid_postcode_with_district_ten_only_with_BS(self, area):
         postcode = mock.Mock(outward=f"{area}10")
         rule = ZeroOrTenDistrict(postcode)
 
-        if area == "BS":
+        if area in ["BS", "OX"]:
             assert rule.validate() is None
         else:
             with pytest.raises(InvalidPostcode):


### PR DESCRIPTION
Hi there,

Many thanks for this library. We've had one user fail validation with a valid postcode. This patch allows for that outward postcode.

I have an example of OX10: https://goo.gl/maps/ey5DDDNQ4n3Um4KSA

Thanks again.